### PR TITLE
fix: validate comments against cumulative PR diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2025-11-26
+
+### Fixed
+- **Comment validation for multi-commit PRs** - Fixed bug where inline review comments on files modified in multiple commits would fail validation and be demoted to issue comments. The validation now uses the cumulative PR diff (base...HEAD) instead of per-commit patches, matching GitHub's actual validation behavior when posting reviews.
+
 ## [3.0.0] - 2025-11-26
 
 ### Added

--- a/dist/index.js
+++ b/dist/index.js
@@ -33567,6 +33567,7 @@ class ReviewService {
             prompt,
             commits: packedCommits,
             skippedCommits,
+            patches: results.patches, // Cumulative PR diff for validation
         };
     }
     async review(options) {
@@ -33586,7 +33587,8 @@ class ReviewService {
         }
         core.info(`Got ${response.comments.length} suggestions from AI.`);
         // 4. Post Comments to PR
-        const result = await this.githubService.postReviewComments(response.comments, options.changesThreshold, pr.commits);
+        const result = await this.githubService.postReviewComments(response.comments, options.changesThreshold, pr.patches // Use cumulative PR diff for validation (matches GitHub's HEAD validation)
+        );
         core.info(`Posted ${result.reviewComments} comments and requested ${result.reviewChanges} changes.`);
         return true;
     }
@@ -33766,22 +33768,22 @@ class GitHubService {
      * - Collects all valid comments and submits ONE review for the entire PR
      * - Uses HEAD sha to avoid "line must be part of diff" errors
      * - Determines review event based on ANY comment meeting severity threshold
+     * - Validates comments against cumulative PR diff (base...HEAD) to match GitHub's validation
      */
-    async postReviewComments(comments, changesThreshold, commits) {
+    async postReviewComments(comments, changesThreshold, patches // Cumulative PR diff (base...HEAD) for validation
+    ) {
         // Get PR details to use HEAD sha for the single review
         const prDetails = await this.getPrDetails();
         const headSha = prDetails.head;
         // Order of severity levels
         const severityOrder = ["info", "warning", "error"];
         const thresholdIndex = severityOrder.indexOf(changesThreshold);
-        // Collect all patches from all commits for validation
-        const allPatches = commits.flatMap((c) => c.patches);
         // Validate and categorize comments
         const validComments = [];
         const issueComments = [];
         for (const c of comments) {
-            // Verify the comment can be placed in the diff
-            const isValid = this.verifyCommentLineInPatch(c.file, c.line, c.side, allPatches, c.start_line, c.start_side);
+            // Verify the comment can be placed in the cumulative PR diff
+            const isValid = this.verifyCommentLineInPatch(c.file, c.line, c.side, patches, c.start_line, c.start_side);
             if (isValid) {
                 validComments.push(c);
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "reviewer",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "reviewer",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "dependencies": {
                 "@actions/core": "^1.11.1",
                 "@actions/github": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reviewer",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": "A GitHub Action that uses Azure OpenAI to generate PR comments.",
     "main": "dist/index.js",
     "type": "module",

--- a/src/githubService.test.ts
+++ b/src/githubService.test.ts
@@ -109,12 +109,7 @@ describe("GitHubService", () => {
       const reviewResult = await service.postReviewComments(
         mockComments,
         "warning",
-        [
-          {
-            commit: { sha: "sha1", message: "Commit message", patches },
-            patches,
-          },
-        ]
+        patches // Cumulative PR diff
       );
 
       expect(reviewResult).toEqual({
@@ -246,16 +241,11 @@ describe("GitHubService", () => {
         },
       ];
 
-      const reviewResult = await service.postReviewComments(comments, "error", [
-        {
-          commit: {
-            sha: "test-sha",
-            message: "Commit message",
-            patches: [],
-          },
-          patches: [],
-        },
-      ]);
+      const reviewResult = await service.postReviewComments(
+        comments,
+        "error",
+        [] // Empty cumulative diff - no patches to validate against
+      );
 
       expect(reviewResult).toEqual({
         reviewChanges: 0,
@@ -325,12 +315,7 @@ describe("GitHubService", () => {
       const reviewResult = await service.postReviewComments(
         infoOnlyComments,
         "error", // High threshold - only errors trigger REQUEST_CHANGES
-        [
-          {
-            commit: { sha: "sha1", message: "Commit message", patches },
-            patches,
-          },
-        ]
+        patches // Cumulative PR diff
       );
 
       expect(reviewResult).toEqual({
@@ -346,6 +331,98 @@ describe("GitHubService", () => {
           event: "COMMENT",
         })
       );
+    });
+
+    /**
+     * Regression test for multi-commit file validation bug.
+     *
+     * Previously, the code used `commits.flatMap(c => c.patches)` and then
+     * `patches.find(p => p.filename === filename)` which would return the
+     * FIRST patch for a file. This meant comments on lines changed in later
+     * commits would fail validation.
+     *
+     * The fix uses the cumulative PR diff (base...HEAD) which contains all
+     * changes merged into a single patch per file.
+     */
+    it("should validate comments against cumulative diff for files modified in multiple commits", async () => {
+      const mockCreateReview = vi.fn().mockResolvedValue({});
+      const mockCreateComment = vi.fn().mockResolvedValue({});
+      const mockGet = vi.fn().mockResolvedValue(mockPrResponse);
+
+      const mockOctokit = {
+        rest: {
+          pulls: {
+            createReview: mockCreateReview,
+            get: mockGet,
+          },
+          issues: {
+            createComment: mockCreateComment,
+          },
+        },
+      };
+
+      (github.getOctokit as MockType).mockReturnValue(mockOctokit);
+
+      const service = new GitHubService(mockConfig);
+
+      // Cumulative PR diff: foo.ts was modified in two commits
+      // - Commit A added lines 1-3
+      // - Commit B added lines 50-52
+      // The cumulative diff contains BOTH hunks merged
+      const cumulativePatch = [
+        {
+          filename: "foo.ts",
+          patch:
+            "@@ -0,0 +1,3 @@\n+Line 1 from commit A\n+Line 2 from commit A\n+Line 3 from commit A\n" +
+            "@@ -47,0 +50,3 @@\n+Line 50 from commit B\n+Line 51 from commit B\n+Line 52 from commit B",
+        },
+      ];
+
+      // Comment targets line 51 - which was added in commit B
+      // With the old bug, this would fail because .find() returned commit A's patch
+      const commentOnLaterCommitChange = [
+        {
+          sha: "commit-b-sha",
+          file: "foo.ts",
+          line: 51,
+          side: "RIGHT" as const,
+          start_line: 51,
+          start_side: "RIGHT" as const,
+          comment: "Issue found on line added in commit B",
+          severity: "warning" as const,
+        },
+      ];
+
+      const reviewResult = await service.postReviewComments(
+        commentOnLaterCommitChange,
+        "warning",
+        cumulativePatch
+      );
+
+      // The comment should be valid (not demoted to issue comment)
+      expect(reviewResult).toEqual({
+        reviewChanges: 1,
+        reviewComments: 0,
+        issueComments: 0,
+      });
+
+      // Should create an inline review, not an issue comment
+      expect(mockCreateReview).toHaveBeenCalledTimes(1);
+      expect(mockCreateReview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "REQUEST_CHANGES",
+          comments: [
+            expect.objectContaining({
+              path: "foo.ts",
+              line: 51,
+              side: "RIGHT",
+            }),
+          ],
+        })
+      );
+
+      // No fallback to issue comments
+      expect(mockCreateComment).not.toHaveBeenCalled();
     });
   });
 

--- a/src/githubService.ts
+++ b/src/githubService.ts
@@ -7,7 +7,6 @@ import {
   findPositionInDiff,
   verifyMultiLineCommentRange,
 } from "./diffparser.js";
-import { type PackedCommit } from "./reviewer.js";
 
 export interface GitHubConfig {
   token: string;
@@ -155,11 +154,12 @@ export class GitHubService {
    * - Collects all valid comments and submits ONE review for the entire PR
    * - Uses HEAD sha to avoid "line must be part of diff" errors
    * - Determines review event based on ANY comment meeting severity threshold
+   * - Validates comments against cumulative PR diff (base...HEAD) to match GitHub's validation
    */
   async postReviewComments(
     comments: z.infer<typeof CodeReviewComment>[],
     changesThreshold: SeverityLevel,
-    commits: PackedCommit[]
+    patches: PatchInfo[] // Cumulative PR diff (base...HEAD) for validation
   ) {
     // Get PR details to use HEAD sha for the single review
     const prDetails = await this.getPrDetails();
@@ -169,20 +169,17 @@ export class GitHubService {
     const severityOrder = ["info", "warning", "error"];
     const thresholdIndex = severityOrder.indexOf(changesThreshold);
 
-    // Collect all patches from all commits for validation
-    const allPatches = commits.flatMap((c) => c.patches);
-
     // Validate and categorize comments
     const validComments: z.infer<typeof CodeReviewComment>[] = [];
     const issueComments: z.infer<typeof CodeReviewComment>[] = [];
 
     for (const c of comments) {
-      // Verify the comment can be placed in the diff
+      // Verify the comment can be placed in the cumulative PR diff
       const isValid = this.verifyCommentLineInPatch(
         c.file,
         c.line,
         c.side,
-        allPatches,
+        patches,
         c.start_line,
         c.start_side
       );

--- a/src/reviewer.test.ts
+++ b/src/reviewer.test.ts
@@ -211,26 +211,8 @@ commit diff
     expect(GitHubService.prototype.postReviewComments).toHaveBeenCalledWith(
       mockAzureResponse.comments,
       "error",
-      [
-        {
-          commit: {
-            message: "test commit",
-            patches: [
-              {
-                filename: "commit.ts",
-                patch: "commit diff",
-              },
-            ],
-            sha: "head-sha",
-          },
-          patches: [
-            {
-              filename: "commit.ts",
-              patch: "commit diff",
-            },
-          ],
-        },
-      ]
+      // Cumulative PR diff (base...HEAD) from compareCommits
+      [{ filename: "commit.ts", patch: "commit diff" }]
     );
 
     // Verify no errors were reported

--- a/src/reviewer.ts
+++ b/src/reviewer.ts
@@ -30,6 +30,7 @@ export type BuildPromptResult = {
   prompt: string;
   commits: PackedCommit[];
   skippedCommits: SkippedCommit[];
+  patches: PatchInfo[]; // Cumulative PR diff (base...HEAD) for validation
 };
 
 export const shouldExcludeFile = (
@@ -230,6 +231,7 @@ export class ReviewService {
       prompt,
       commits: packedCommits,
       skippedCommits,
+      patches: results.patches, // Cumulative PR diff for validation
     } satisfies BuildPromptResult;
   }
 
@@ -258,7 +260,7 @@ export class ReviewService {
     const result = await this.githubService.postReviewComments(
       response.comments,
       options.changesThreshold,
-      pr.commits
+      pr.patches // Use cumulative PR diff for validation (matches GitHub's HEAD validation)
     );
 
     core.info(


### PR DESCRIPTION
Previously, postReviewComments used per-commit patches and .find() to
validate comment lines, which returned the first patch for a file.
This caused comments on files modified in multiple commits to fail
validation when referencing lines from later commits.

Now uses the cumulative PR diff (base...HEAD) for validation, matching
GitHub's actual behavior when posting reviews with HEAD sha.

- Updated BuildPromptResult to include cumulative patches
- Changed postReviewComments to accept PatchInfo[] instead of PackedCommit[]
- Added regression test for multi-commit file scenario
- Bumped version to 3.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>