### PR TITLE
fix: reject multi-line comments spanning multiple hunks

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33720,14 +33720,111 @@ class ReviewService {
 
 ;// CONCATENATED MODULE: ./src/diffparser.ts
 /**
- * Finds the line position of a specified line number (newFileLine) within a unified diff patch.
+ * Parses a unified diff patch into a structured representation.
+ * Single-pass parser that extracts all structural information including hunk boundaries.
  *
- * Algorithm explanation:
- * 1. Split the patch into lines and iterate through them.
- * 2. Ignore lines until the first '@@' hunk header is encountered.
- * 3. From that point on, increment a counter for each line that is an addition ("+") or unmodified line (" ").
- * 4. If the counter matches the target newFileLine, the position returned is how many lines have passed
- *    since the first '@@' hunk header.
+ * @param patch  Unified diff string
+ * @returns      Parsed diff structure with line and hunk information
+ */
+function parseDiff(patch) {
+    const lines = patch.split("\n");
+    const result = {
+        lines: new Map(),
+        hunks: [],
+        oldLineIndex: new Map(),
+        newLineIndex: new Map(),
+    };
+    let trackedOldLine = 0;
+    let trackedNewLine = 0;
+    let hasFoundFirstHunk = false;
+    let firstHunkLineIndex = -1;
+    let currentHunkIndex = -1;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        // Detect a hunk header, e.g. "@@ -123,4 +567,8 @@"
+        if (line.startsWith("@@ ")) {
+            const match = line.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+            if (match) {
+                const oldStart = parseInt(match[1], 10);
+                const newStart = parseInt(match[3], 10);
+                trackedOldLine = oldStart - 1;
+                trackedNewLine = newStart - 1;
+                if (!hasFoundFirstHunk) {
+                    hasFoundFirstHunk = true;
+                    firstHunkLineIndex = i;
+                }
+                currentHunkIndex++;
+                const position = i - firstHunkLineIndex;
+                result.hunks.push({
+                    index: currentHunkIndex,
+                    headerPosition: position,
+                    oldStart,
+                    newStart,
+                });
+                result.lines.set(position, {
+                    position,
+                    oldLine: null,
+                    newLine: null,
+                    type: "hunk",
+                    hunkIndex: currentHunkIndex,
+                });
+            }
+            continue;
+        }
+        // Skip lines until we've encountered the first "@@"
+        if (!hasFoundFirstHunk) {
+            continue;
+        }
+        const position = i - firstHunkLineIndex;
+        let diffLine;
+        if (line.startsWith(" ")) {
+            // Context line - appears in both old and new
+            trackedOldLine++;
+            trackedNewLine++;
+            diffLine = {
+                position,
+                oldLine: trackedOldLine,
+                newLine: trackedNewLine,
+                type: "context",
+                hunkIndex: currentHunkIndex,
+            };
+            result.oldLineIndex.set(trackedOldLine, diffLine);
+            result.newLineIndex.set(trackedNewLine, diffLine);
+        }
+        else if (line.startsWith("-")) {
+            // Deleted line - only in old file (LEFT)
+            trackedOldLine++;
+            diffLine = {
+                position,
+                oldLine: trackedOldLine,
+                newLine: null,
+                type: "deletion",
+                hunkIndex: currentHunkIndex,
+            };
+            result.oldLineIndex.set(trackedOldLine, diffLine);
+        }
+        else if (line.startsWith("+")) {
+            // Added line - only in new file (RIGHT)
+            trackedNewLine++;
+            diffLine = {
+                position,
+                oldLine: null,
+                newLine: trackedNewLine,
+                type: "addition",
+                hunkIndex: currentHunkIndex,
+            };
+            result.newLineIndex.set(trackedNewLine, diffLine);
+        }
+        else {
+            // Unknown line type (e.g., "\ No newline at end of file")
+            continue;
+        }
+        result.lines.set(position, diffLine);
+    }
+    return result;
+}
+/**
+ * Finds the line position of a specified line number within a unified diff patch.
  *
  * According to GitHub's specification:
  * "The position value equals the number of lines down from the first '@@' hunk header
@@ -33741,68 +33838,16 @@ class ReviewService {
  * @returns           Position in the diff, or null if not found
  */
 function findPositionInDiff(patch, targetLine, side) {
-    // Split into lines
-    const lines = patch.split("\n");
-    // Tracks the current line number in the old file and new file
-    let trackedOldLine = 0;
-    let trackedNewLine = 0;
-    // Indicates if we've encountered the first "@@" hunk header
-    let hasFoundFirstHunk = false;
-    // Zero-based index of the line where the first "@@" occurs
-    let firstHunkLineIndex = -1;
-    for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        // Detect a hunk header, e.g. "@@ -123,4 +567,8 @@"
-        if (line.startsWith("@@ ")) {
-            // Attempt to parse the old/new line starts
-            const match = line.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
-            if (match) {
-                // We only care about the starting line numbers, ignoring lengths for this purpose
-                const oldStart = parseInt(match[1], 10);
-                const newStart = parseInt(match[3], 10);
-                trackedOldLine = oldStart - 1;
-                trackedNewLine = newStart - 1;
-                if (!hasFoundFirstHunk) {
-                    hasFoundFirstHunk = true;
-                    firstHunkLineIndex = i;
-                }
-            }
-            continue;
-        }
-        // Skip lines until we've encountered the first "@@"
-        if (!hasFoundFirstHunk) {
-            continue;
-        }
-        // In a unified diff:
-        //   - lines starting with " " appear in both old and new
-        //   - lines starting with "-" only appear in old
-        //   - lines starting with "+" only appear in new
-        if (line.startsWith(" ")) {
-            // Unmodified line on both sides
-            trackedOldLine++;
-            trackedNewLine++;
-        }
-        else if (line.startsWith("-")) {
-            // Deleted line, only on old (LEFT)
-            trackedOldLine++;
-        }
-        else if (line.startsWith("+")) {
-            // Added line, only on new (RIGHT)
-            trackedNewLine++;
-        }
-        // Check if we've hit the target line for the requested side
-        if (side === "LEFT" && trackedOldLine === targetLine) {
-            return i - firstHunkLineIndex;
-        }
-        if (side === "RIGHT" && trackedNewLine === targetLine) {
-            return i - firstHunkLineIndex;
-        }
-    }
-    // If we exhaust the patch lines without matching targetLine, return null
-    return null;
+    const parsed = parseDiff(patch);
+    const index = side === "LEFT" ? parsed.oldLineIndex : parsed.newLineIndex;
+    return index.get(targetLine)?.position ?? null;
 }
 /**
  * Verifies if a multi-line comment range is valid within a diff patch.
+ *
+ * GitHub requires that multi-line comments have both start and end lines
+ * within the same hunk. This function validates that constraint by parsing
+ * the diff and comparing hunk indices.
  *
  * @param patch       Unified diff string
  * @param startLine   Starting line number in the file
@@ -33812,15 +33857,27 @@ function findPositionInDiff(patch, targetLine, side) {
  * @returns           Object with start and end positions, or null if invalid
  */
 function verifyMultiLineCommentRange(patch, startLine, endLine, startSide, endSide) {
-    const startPosition = findPositionInDiff(patch, startLine, startSide);
-    const endPosition = findPositionInDiff(patch, endLine, endSide);
-    if (startPosition === null || endPosition === null) {
+    const parsed = parseDiff(patch);
+    const startIndex = startSide === "LEFT" ? parsed.oldLineIndex : parsed.newLineIndex;
+    const endIndex = endSide === "LEFT" ? parsed.oldLineIndex : parsed.newLineIndex;
+    const startDiffLine = startIndex.get(startLine);
+    const endDiffLine = endIndex.get(endLine);
+    // Both lines must exist in the diff
+    if (!startDiffLine || !endDiffLine) {
         return null;
     }
-    if (startPosition > endPosition) {
+    // Start position must come before or equal to end position
+    if (startDiffLine.position > endDiffLine.position) {
         return null;
     }
-    return { startPosition, endPosition };
+    // Both lines must be in the same hunk (GitHub API requirement)
+    if (startDiffLine.hunkIndex !== endDiffLine.hunkIndex) {
+        return null;
+    }
+    return {
+        startPosition: startDiffLine.position,
+        endPosition: endDiffLine.position,
+    };
 }
 
 ;// CONCATENATED MODULE: ./src/githubService.ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reviewer",
-    "version": "3.2.0",
+    "version": "3.3.0",
     "description": "A GitHub Action that uses Azure OpenAI to generate PR comments.",
     "main": "dist/index.js",
     "type": "module",

--- a/src/diffparser.test.ts
+++ b/src/diffparser.test.ts
@@ -1,6 +1,7 @@
 import {
   findPositionInDiff,
   verifyMultiLineCommentRange,
+  parseDiff,
 } from "./diffparser.js";
 
 describe("findPositionInDiff", () => {
@@ -259,5 +260,160 @@ describe("verifyMultiLineCommentRange", () => {
       "LEFT"
     );
     expect(result).not.toBeNull();
+  });
+
+  describe("cross-hunk detection", () => {
+    const multiHunkPatch = `@@ -1,3 +1,4 @@
+ line one
+-old line
++new line
+ line three
+@@ -10,2 +11,3 @@
+ other content
++added line
+ final line`;
+
+    it("returns null when range spans across hunks (RIGHT side)", () => {
+      // Line 3 is in hunk 0 (position 4), line 11 is in hunk 1 (position 6)
+      // This should return null because they span different hunks
+      const result = verifyMultiLineCommentRange(
+        multiHunkPatch,
+        3, // line three (hunk 0)
+        11, // other content (hunk 1)
+        "RIGHT",
+        "RIGHT"
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null when range spans across hunks (LEFT side)", () => {
+      // Line 3 is in hunk 0, line 10 is in hunk 1
+      const result = verifyMultiLineCommentRange(
+        multiHunkPatch,
+        3, // line three (hunk 0)
+        10, // other content (hunk 1)
+        "LEFT",
+        "LEFT"
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns positions when range is within first hunk (RIGHT side)", () => {
+      // Lines 1-3 are all in hunk 0
+      const result = verifyMultiLineCommentRange(
+        multiHunkPatch,
+        1, // line one (hunk 0)
+        3, // line three (hunk 0)
+        "RIGHT",
+        "RIGHT"
+      );
+      expect(result).not.toBeNull();
+      expect(result?.startPosition).toBe(1);
+      expect(result?.endPosition).toBe(4);
+    });
+
+    it("returns positions when range is within second hunk (RIGHT side)", () => {
+      // Lines 11-13 are all in hunk 1
+      const result = verifyMultiLineCommentRange(
+        multiHunkPatch,
+        11, // other content (hunk 1)
+        13, // final line (hunk 1)
+        "RIGHT",
+        "RIGHT"
+      );
+      expect(result).not.toBeNull();
+      expect(result?.startPosition).toBe(6);
+      expect(result?.endPosition).toBe(8);
+    });
+
+    it("returns null when start line is at end of first hunk and end line is at start of second hunk", () => {
+      // This is a boundary case - line 4 (hunk 0) to line 11 (hunk 1)
+      const result = verifyMultiLineCommentRange(
+        multiHunkPatch,
+        4, // line four - doesn't exist in this patch, last line of hunk 0 content is line 3
+        11,
+        "RIGHT",
+        "RIGHT"
+      );
+      // Line 4 doesn't exist in the diff, so this should return null
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe("parseDiff", () => {
+  it("correctly identifies hunk count", () => {
+    const patch = `@@ -1,2 +1,2 @@
+ line one
++added
+@@ -10,1 +11,1 @@
+ other`;
+
+    const parsed = parseDiff(patch);
+
+    expect(parsed.hunks).toHaveLength(2);
+    expect(parsed.hunks[0].index).toBe(0);
+    expect(parsed.hunks[1].index).toBe(1);
+  });
+
+  it("associates lines with correct hunks", () => {
+    const patch = `@@ -1,1 +1,1 @@
++first hunk line
+@@ -10,1 +11,1 @@
++second hunk line`;
+
+    const parsed = parseDiff(patch);
+
+    const firstLine = parsed.newLineIndex.get(1);
+    const secondLine = parsed.newLineIndex.get(11);
+
+    expect(firstLine?.hunkIndex).toBe(0);
+    expect(secondLine?.hunkIndex).toBe(1);
+  });
+
+  it("handles empty patch", () => {
+    const parsed = parseDiff("");
+
+    expect(parsed.hunks).toHaveLength(0);
+    expect(parsed.lines.size).toBe(0);
+    expect(parsed.oldLineIndex.size).toBe(0);
+    expect(parsed.newLineIndex.size).toBe(0);
+  });
+
+  it("correctly maps line positions", () => {
+    const patch = `@@ -1,3 +1,4 @@
+ line one
+-old line
++new line
+ line three`;
+
+    const parsed = parseDiff(patch);
+
+    // Position 1 = "line one" (context)
+    // Position 2 = "old line" (deletion)
+    // Position 3 = "new line" (addition)
+    // Position 4 = "line three" (context)
+
+    expect(parsed.newLineIndex.get(1)?.position).toBe(1); // line one
+    expect(parsed.newLineIndex.get(2)?.position).toBe(3); // new line
+    expect(parsed.newLineIndex.get(3)?.position).toBe(4); // line three
+
+    expect(parsed.oldLineIndex.get(1)?.position).toBe(1); // line one
+    expect(parsed.oldLineIndex.get(2)?.position).toBe(2); // old line
+    expect(parsed.oldLineIndex.get(3)?.position).toBe(4); // line three
+  });
+
+  it("correctly identifies line types", () => {
+    const patch = `@@ -1,2 +1,2 @@
+ context line
+-deleted line
++added line`;
+
+    const parsed = parseDiff(patch);
+
+    expect(parsed.lines.get(0)?.type).toBe("hunk");
+    expect(parsed.lines.get(1)?.type).toBe("context");
+    expect(parsed.lines.get(2)?.type).toBe("deletion");
+    expect(parsed.lines.get(3)?.type).toBe("addition");
   });
 });

--- a/src/diffparser.ts
+++ b/src/diffparser.ts
@@ -1,12 +1,164 @@
 /**
- * Finds the line position of a specified line number (newFileLine) within a unified diff patch.
+ * Represents a parsed line from a unified diff
+ */
+interface DiffLine {
+  /** Position in the diff (1-indexed from first @@ header) */
+  position: number;
+  /** Line number in the old file (LEFT side), or null if not applicable */
+  oldLine: number | null;
+  /** Line number in the new file (RIGHT side), or null if not applicable */
+  newLine: number | null;
+  /** Type of line: context, addition, deletion, or hunk header */
+  type: "context" | "addition" | "deletion" | "hunk";
+  /** Index of the hunk this line belongs to (0-indexed) */
+  hunkIndex: number;
+}
+
+/**
+ * Represents a parsed hunk from a unified diff
+ */
+interface ParsedHunk {
+  /** 0-indexed hunk number */
+  index: number;
+  /** Position of the @@ line in the diff */
+  headerPosition: number;
+  /** Starting line number in old file */
+  oldStart: number;
+  /** Starting line number in new file */
+  newStart: number;
+}
+
+/**
+ * Complete parsed representation of a unified diff
+ */
+interface ParsedDiff {
+  /** All parsed lines indexed by position */
+  lines: Map<number, DiffLine>;
+  /** All hunks in order */
+  hunks: ParsedHunk[];
+  /** Quick lookup: old line number -> DiffLine */
+  oldLineIndex: Map<number, DiffLine>;
+  /** Quick lookup: new line number -> DiffLine */
+  newLineIndex: Map<number, DiffLine>;
+}
+
+/**
+ * Parses a unified diff patch into a structured representation.
+ * Single-pass parser that extracts all structural information including hunk boundaries.
  *
- * Algorithm explanation:
- * 1. Split the patch into lines and iterate through them.
- * 2. Ignore lines until the first '@@' hunk header is encountered.
- * 3. From that point on, increment a counter for each line that is an addition ("+") or unmodified line (" ").
- * 4. If the counter matches the target newFileLine, the position returned is how many lines have passed
- *    since the first '@@' hunk header.
+ * @param patch  Unified diff string
+ * @returns      Parsed diff structure with line and hunk information
+ */
+export function parseDiff(patch: string): ParsedDiff {
+  const lines = patch.split("\n");
+  const result: ParsedDiff = {
+    lines: new Map(),
+    hunks: [],
+    oldLineIndex: new Map(),
+    newLineIndex: new Map(),
+  };
+
+  let trackedOldLine = 0;
+  let trackedNewLine = 0;
+  let hasFoundFirstHunk = false;
+  let firstHunkLineIndex = -1;
+  let currentHunkIndex = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Detect a hunk header, e.g. "@@ -123,4 +567,8 @@"
+    if (line.startsWith("@@ ")) {
+      const match = line.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+      if (match) {
+        const oldStart = parseInt(match[1], 10);
+        const newStart = parseInt(match[3], 10);
+
+        trackedOldLine = oldStart - 1;
+        trackedNewLine = newStart - 1;
+
+        if (!hasFoundFirstHunk) {
+          hasFoundFirstHunk = true;
+          firstHunkLineIndex = i;
+        }
+
+        currentHunkIndex++;
+        const position = i - firstHunkLineIndex;
+
+        result.hunks.push({
+          index: currentHunkIndex,
+          headerPosition: position,
+          oldStart,
+          newStart,
+        });
+
+        result.lines.set(position, {
+          position,
+          oldLine: null,
+          newLine: null,
+          type: "hunk",
+          hunkIndex: currentHunkIndex,
+        });
+      }
+      continue;
+    }
+
+    // Skip lines until we've encountered the first "@@"
+    if (!hasFoundFirstHunk) {
+      continue;
+    }
+
+    const position = i - firstHunkLineIndex;
+    let diffLine: DiffLine;
+
+    if (line.startsWith(" ")) {
+      // Context line - appears in both old and new
+      trackedOldLine++;
+      trackedNewLine++;
+      diffLine = {
+        position,
+        oldLine: trackedOldLine,
+        newLine: trackedNewLine,
+        type: "context",
+        hunkIndex: currentHunkIndex,
+      };
+      result.oldLineIndex.set(trackedOldLine, diffLine);
+      result.newLineIndex.set(trackedNewLine, diffLine);
+    } else if (line.startsWith("-")) {
+      // Deleted line - only in old file (LEFT)
+      trackedOldLine++;
+      diffLine = {
+        position,
+        oldLine: trackedOldLine,
+        newLine: null,
+        type: "deletion",
+        hunkIndex: currentHunkIndex,
+      };
+      result.oldLineIndex.set(trackedOldLine, diffLine);
+    } else if (line.startsWith("+")) {
+      // Added line - only in new file (RIGHT)
+      trackedNewLine++;
+      diffLine = {
+        position,
+        oldLine: null,
+        newLine: trackedNewLine,
+        type: "addition",
+        hunkIndex: currentHunkIndex,
+      };
+      result.newLineIndex.set(trackedNewLine, diffLine);
+    } else {
+      // Unknown line type (e.g., "\ No newline at end of file")
+      continue;
+    }
+
+    result.lines.set(position, diffLine);
+  }
+
+  return result;
+}
+
+/**
+ * Finds the line position of a specified line number within a unified diff patch.
  *
  * According to GitHub's specification:
  * "The position value equals the number of lines down from the first '@@' hunk header
@@ -24,80 +176,17 @@ export function findPositionInDiff(
   targetLine: number,
   side: "LEFT" | "RIGHT"
 ): number | null {
-  // Split into lines
-  const lines = patch.split("\n");
-
-  // Tracks the current line number in the old file and new file
-  let trackedOldLine = 0;
-  let trackedNewLine = 0;
-
-  // Indicates if we've encountered the first "@@" hunk header
-  let hasFoundFirstHunk = false;
-
-  // Zero-based index of the line where the first "@@" occurs
-  let firstHunkLineIndex = -1;
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-
-    // Detect a hunk header, e.g. "@@ -123,4 +567,8 @@"
-    if (line.startsWith("@@ ")) {
-      // Attempt to parse the old/new line starts
-      const match = line.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
-      if (match) {
-        // We only care about the starting line numbers, ignoring lengths for this purpose
-        const oldStart = parseInt(match[1], 10);
-        const newStart = parseInt(match[3], 10);
-
-        trackedOldLine = oldStart - 1;
-        trackedNewLine = newStart - 1;
-
-        if (!hasFoundFirstHunk) {
-          hasFoundFirstHunk = true;
-          firstHunkLineIndex = i;
-        }
-      }
-
-      continue;
-    }
-
-    // Skip lines until we've encountered the first "@@"
-    if (!hasFoundFirstHunk) {
-      continue;
-    }
-
-    // In a unified diff:
-    //   - lines starting with " " appear in both old and new
-    //   - lines starting with "-" only appear in old
-    //   - lines starting with "+" only appear in new
-
-    if (line.startsWith(" ")) {
-      // Unmodified line on both sides
-      trackedOldLine++;
-      trackedNewLine++;
-    } else if (line.startsWith("-")) {
-      // Deleted line, only on old (LEFT)
-      trackedOldLine++;
-    } else if (line.startsWith("+")) {
-      // Added line, only on new (RIGHT)
-      trackedNewLine++;
-    }
-
-    // Check if we've hit the target line for the requested side
-    if (side === "LEFT" && trackedOldLine === targetLine) {
-      return i - firstHunkLineIndex;
-    }
-    if (side === "RIGHT" && trackedNewLine === targetLine) {
-      return i - firstHunkLineIndex;
-    }
-  }
-
-  // If we exhaust the patch lines without matching targetLine, return null
-  return null;
+  const parsed = parseDiff(patch);
+  const index = side === "LEFT" ? parsed.oldLineIndex : parsed.newLineIndex;
+  return index.get(targetLine)?.position ?? null;
 }
 
 /**
  * Verifies if a multi-line comment range is valid within a diff patch.
+ *
+ * GitHub requires that multi-line comments have both start and end lines
+ * within the same hunk. This function validates that constraint by parsing
+ * the diff and comparing hunk indices.
  *
  * @param patch       Unified diff string
  * @param startLine   Starting line number in the file
@@ -113,16 +202,33 @@ export function verifyMultiLineCommentRange(
   startSide: "LEFT" | "RIGHT",
   endSide: "LEFT" | "RIGHT"
 ): { startPosition: number; endPosition: number } | null {
-  const startPosition = findPositionInDiff(patch, startLine, startSide);
-  const endPosition = findPositionInDiff(patch, endLine, endSide);
+  const parsed = parseDiff(patch);
 
-  if (startPosition === null || endPosition === null) {
+  const startIndex =
+    startSide === "LEFT" ? parsed.oldLineIndex : parsed.newLineIndex;
+  const endIndex =
+    endSide === "LEFT" ? parsed.oldLineIndex : parsed.newLineIndex;
+
+  const startDiffLine = startIndex.get(startLine);
+  const endDiffLine = endIndex.get(endLine);
+
+  // Both lines must exist in the diff
+  if (!startDiffLine || !endDiffLine) {
     return null;
   }
 
-  if (startPosition > endPosition) {
+  // Start position must come before or equal to end position
+  if (startDiffLine.position > endDiffLine.position) {
     return null;
   }
 
-  return { startPosition, endPosition };
+  // Both lines must be in the same hunk (GitHub API requirement)
+  if (startDiffLine.hunkIndex !== endDiffLine.hunkIndex) {
+    return null;
+  }
+
+  return {
+    startPosition: startDiffLine.position,
+    endPosition: endDiffLine.position,
+  };
 }


### PR DESCRIPTION
## Summary

- Fixes GitHub API error "Pull request review thread start line must be part of the same hunk as the line" (422 Unprocessable Entity)
- Introduces single-pass diff parser (`parseDiff`) with hunk boundary tracking
- Comments spanning multiple hunks now gracefully fall back to issue comments

## Changes

- Add `DiffLine`, `ParsedHunk`, `ParsedDiff` types for structured diff parsing
- Implement `parseDiff()` function with hunk index tracking
- Update `verifyMultiLineCommentRange()` to compare `hunkIndex` values
- Refactor `findPositionInDiff()` to use `parseDiff()` internally
- Add 10 new test cases for cross-hunk detection and `parseDiff()`
- Bump version to 3.3.0

## Test plan

- [x] All 133 tests pass
- [x] Build passes
- [x] Lint passes
- [ ] Deploy to staging and verify multi-hunk comments fall back to issue comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)